### PR TITLE
Fix stage filters in pipeline analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/src/Code.ts
+++ b/src/Code.ts
@@ -43,6 +43,7 @@ function getDashboardData(params) {
     var days = params.days || 30;
     var pipelineFilter = params.pipelineFilter ? new RegExp(params.pipelineFilter, 'i') : null;
     var stageFilter = params.stageFilter ? new RegExp(params.stageFilter, 'i') : null;
+    var stageTypeFilter = params.stageTypeFilter ? params.stageTypeFilter.toLowerCase() : null;
     var cacheKey = JSON.stringify(params);
     // 2. VERIFICAR CACHÉ (COMPROBACIÓN COMPLETA)
     if (CACHE.statistics && 
@@ -82,7 +83,6 @@ function getDashboardData(params) {
         processed: 0
       }
     };
-    analysis.pipelineStats = [];
     analysis.pipelineStats = {};
     
     var cutoffDate = new Date();
@@ -156,12 +156,16 @@ function getDashboardData(params) {
               // Clasificar el stage por tipo
               const stageName = stage.name.toLowerCase();
               let stageType = 'other';
-              
+
               if (stageName.includes('test')) stageType = 'tests';
               else if (stageName.includes('build')) stageType = 'build';
               else if (stageName.includes('deploy')) stageType = 'deploy';
               else if (stageName.includes('secure')) stageType = 'security';
-              
+
+              // Aplicar filtros de stage
+              if (stageFilter && !stageFilter.test(stage.name)) return;
+              if (stageTypeFilter && stageType !== stageTypeFilter) return;
+
               failedStages.push({
                 name: stage.name,
                 type: stageType


### PR DESCRIPTION
## Summary
- ignore node_modules
- use stage filter and stage type filter in API logic
- remove redundant pipelineStats initialization

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688a28b7efa08324906e942dc9ee7696